### PR TITLE
Added my email to the Code of Conduct, update the link in CONTRIBUTING.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ contributors of this MDS project pledge to making participation in our project a
 level of experience, education, socio-economic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.  All participants in this project are expected to show respect and courtesy to others.
 
-Contributors of this project are responsible for enforcing the Code of Conduct. They can be contacted by emailing niruidan@gmail.com and/or amarria1@gmail.com. All reports will be kept confidential.
+Contributors of this project are responsible for enforcing the Code of Conduct. They can be contacted by emailing niruidan@gmail.com and/or amarria1@gmail.com and/or yuejiang001@outlook.com. All reports will be kept confidential.
 
 ## Our Standards
 
@@ -44,7 +44,7 @@ that are not aligned to this Code of Conduct.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at niruidan@gmail.com or amarria1@gmail.com. All
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at niruidan@gmail.com or amarria1@gmail.com or yuejiang001@outlook.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks you for taking the time to contribute! 
 
-If you notice a bug, or have a feature request, please open up an issue [here](https://github.com/UBC-MDS/DSCI-532_group-211_dashboards/pulls). If you’d like to contribute a feature or bug fix, you can fork our repo and submit a pull request. Before you make a substantial pull request, we encourage you to file an issue and make sure someone from our team agrees that it's a problem. If you've found a issue, please create an associated issue and illustrate the issue with a screenshot and description. We will review pull requests within 7 days. 
+If you notice a bug, or have a feature request, please open up an issue [here](https://github.com/UBC-MDS/DSCI-532_group-211_dashboards/issues). If you’d like to contribute a feature or bug fix, you can fork our repo and submit a pull request. Before you make a substantial pull request, we encourage you to file an issue and make sure someone from our team agrees that it's a problem. If you've found a issue, please create an associated issue and illustrate the issue with a screenshot and description. We will review pull requests within 7 days. 
 
 All contributors must abide by our code of conduct, which can be found [here](https://github.com/UBC-MDS/DSCI-532_group-211_dashboards/blob/master/CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
Hi team,

I added my email to the Code of Conduct. 
Another thing I found is that in the CONTRIBUTING.md, the original first link points to the "Pull request", but according to my understanding of the sentence, it should point to the "Issue" part on Github. So I changed it. 
Please take a look. If you are OK with the changes, please kindly merge it. Thanks. 

Alex